### PR TITLE
[CSA-2133] add custom status endpoint to find status id

### DIFF
--- a/lib/dock_health_api.rb
+++ b/lib/dock_health_api.rb
@@ -27,6 +27,7 @@ module DockHealthApi
   autoload :Developer, "dock_health_api/resources/developer"
   autoload :Organization, "dock_health_api/resources/organization"
   autoload :CustomField, "dock_health_api/resources/customfield"
+  autoload :CustomStatus, "dock_health_api/resources/customstatus"
 
   @config = DockHealthApi::Config.new
   @iframe_base_url = "https://dev.dockhealth.app/#/auth/embedded?"

--- a/lib/dock_health_api/resources/customstatus.rb
+++ b/lib/dock_health_api/resources/customstatus.rb
@@ -1,0 +1,9 @@
+module DockHealthApi
+  class CustomStatus < Resource
+    extend DockHealthApi::Crud::List
+
+    def self.resource_url
+      "#{client.config.resource_url}/api/#{url_version}/configuration/status"
+    end
+  end
+end

--- a/lib/dock_health_api/version.rb
+++ b/lib/dock_health_api/version.rb
@@ -1,3 +1,3 @@
 module DockHealthApi
-  VERSION = "0.5.1"
+  VERSION = "0.5.2"
 end

--- a/spec/customstatus_spec.rb
+++ b/spec/customstatus_spec.rb
@@ -1,0 +1,14 @@
+require 'dock_health_api'
+require 'spec_helper'
+
+RSpec.describe DockHealthApi::CustomStatus do
+
+  describe "#list" do
+    context "list all customstatus" do
+      it 'should list all customstatus' do
+        response = DockHealthApi::CustomStatus.list
+        expect(response.first.is_a?(DockHealthApi::CustomStatus))
+      end
+    end
+  end
+end


### PR DESCRIPTION
We only need `List` at this time, should I just extend that for now or include all the crud actions?